### PR TITLE
Add PRU camera library and f/w, nonblocking main IO, and logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skeleton-bbbl
 
-## Building
+## Building main code
 This repository is set up to build under either Eclipse IDE with cross-compilation, or make on the target device.
 
 Important: both are distinct build flows, and likely will not produce equivalent binaries because of possible differences in compiler versions and flags. We recommend you standardize and stick to one.
@@ -22,3 +22,7 @@ You can symlink `/etc/robotcontrol/link_to_startup_program` to your binary to ru
 You can run make in the repository root. All `.c` and `.cpp` files in `src/` will be automatically detected for compilation, and create a binary called `build/main`. 
 
 The make target `runonboot` is provided to run the compiled target on the BeagleBoneBlue's boot.
+
+## Building PRU code
+See [the pru_firmware readme](pru_firmware/README.md).
+You will need to build the PRU firmware to use the PruCamera library.

--- a/pru_firmware/Makefile
+++ b/pru_firmware/Makefile
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+#
+# much thanks to Zubeen Tolani and Mark Yoder for porting this pru code
+# to remoteproc.
+
+
+SRC_DIR		:= src
+BUILD_DIR	:= build
+BIN_DIR		:= $(BUILD_DIR)/fw
+
+PRU0_FW		:= am335x-pru0-custom-fw
+PRU1_FW		:= am335x-pru1-rc-servo-fw
+
+TARGET0		:= $(BIN_DIR)/$(PRU0_FW)
+TARGET1		:= $(BIN_DIR)/$(PRU1_FW)
+TARGETS		:= $(TARGET0) $(TARGET1)
+LINK_PRU1_FW	:= $(BUILD_DIR)/pru1-servo.object
+
+RM		:= rm -f -r
+INSTALL		:= install -m 755
+INSTALLDIR	:= install -d -m 755
+INSTALLNONEXEC	:= install -m 644
+
+
+PRU_CGT		:= /usr/share/ti/cgt-pru
+LNKPRU		:= /usr/bin/lnkpru
+CLPRU		:= /usr/bin/clpru
+
+# if the pru-software-support-package is installed to /opt/ use that
+# otherwise look in /usr/lib/ti/ which is where the BBB images puts it
+ifneq ("$(wildcard /opt/source/pru-software-support-package/lib/rpmsg_lib.lib)","")
+LIBS=--library=/opt/source/pru-software-support-package/lib/rpmsg_lib.lib
+INCLUDE=--include_path=/opt/source/pru-software-support-package/include \
+--include_path=/opt/source/pru-software-support-package/include/am335x \
+--include_path=$(PRU_CGT)/include
+else
+LIBS=--library=/usr/lib/ti/pru-software-support-package/lib/rpmsg_lib.lib
+INCLUDE=--include_path=/usr/lib/ti/pru-software-support-package/include \
+--include_path=/usr/lib/ti/pru-software-support-package/include/am335x \
+--include_path=$(PRU_CGT)/include
+endif
+
+
+LINKER_COMMAND_FILE=./$(SRC_DIR)/AM335x_PRU.cmd
+STACK_SIZE=0x100
+HEAP_SIZE=0x100
+
+
+CFLAGS=-v3 -O2 --display_error_number --endian=little --hardware_mac=on --obj_directory=$(BUILD_DIR) --pp_directory=$(BUILD_DIR)
+LFLAGS=--reread_libs --warn_sections --stack_size=$(STACK_SIZE) --heap_size=$(HEAP_SIZE) -m $(BUILD_DIR)/file.map
+
+
+
+all: $(TARGETS)
+	@echo "Generated: $^"
+
+
+$(TARGET0): $(BUILD_DIR)/main_pru0.object
+	@echo 'LD	$^'
+	@mkdir -p $(BIN_DIR)
+	@$(LNKPRU) -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $@ $^  $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS) $^
+
+$(TARGET1): $(BUILD_DIR)/main_pru1.object $(LINK_PRU1_FW)
+	@echo 'LD	$^'
+	@mkdir -p $(BIN_DIR)
+	@$(LNKPRU) -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $@ $^  $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS) $^
+
+
+$(BUILD_DIR)/main_pru0.object: $(SRC_DIR)/main_pru0.c
+	@mkdir -p $(BUILD_DIR)
+	@echo 'CC	$<'
+	@$(CLPRU)  $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+
+$(BUILD_DIR)/main_pru1.object: $(SRC_DIR)/main_pru1.c
+	@mkdir -p $(BUILD_DIR)
+	@echo 'CC	$<'
+	@$(CLPRU)  $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+
+$(BUILD_DIR)/pru1-servo.object: $(SRC_DIR)/pru1-servo.asm
+	@mkdir -p $(BUILD_DIR)
+	@echo 'CC	$<'
+	@$(CLPRU)  $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+
+
+install: $(TARGET0) $(TARGET1)
+	@$(INSTALLDIR) $(DESTDIR)/lib/firmware
+	@$(INSTALLNONEXEC) $(TARGET0) $(DESTDIR)/lib/firmware/
+	@$(INSTALLNONEXEC) $(TARGET1) $(DESTDIR)/lib/firmware/
+	@echo 'PRU Firmware Install Complete'
+
+
+clean:
+	@$(RM) $(BUILD_DIR)
+	@$(RM) $(BIN_DIR)
+	@$(RM) main_pru1.asm main_pru0.asm file.map
+	@echo 'PRU Firmware Cleanup Complete'
+
+uninstall:
+	@$(RM) $(DESTDIR)/lib/firmware/$(PRU0_FW)
+	@$(RM) $(DESTDIR)$(DESTDIR)/lib/firmware/$(PRU1_FW)
+	@echo "PRU Firmware Uninstall Complete"

--- a/pru_firmware/README.md
+++ b/pru_firmware/README.md
@@ -1,0 +1,27 @@
+Code for Programmable Realtime Unit (coprocessor)
+
+## Components
+### PRU0: Linescan
+PRU0 is the line camera code, generating the SI/CLK signals and sampling the AO from the camera, written in C.
+As currently written, it spends 100ms at the beginning pulsing the red LED to indicate a successful boot, then drives the red LED while it is reading the camera.
+
+Partial register definitions (at least what is directly used) for the GPIO and clock are provided.
+Register definitions for the ADC can be found on the BeagleBoneBlue at `/usr/lib/ti/pru-software-support-package/include/am335x/sys_tscAdcSs.h`.
+
+Note: PRU0 originally was used by librobotcontrol for the 4th encoder - and since we're repurposing PRU0, only the three eQEP-based encoders can be used.
+
+### PRU1: Servo
+This is the unmodified servo PRU code from [librobotcontrol](https://github.com/StrawsonDesign/librobotcontrol), written in assembly.
+
+## Building
+On the BeagleBoneBlue, run:
+```
+make
+```
+which will place the built firmware objects in `build/fw`.
+
+To install the built firmware (so it is accessible from `rc_pru_start`), run:
+```
+make install
+```
+which will copy the built firmware to `/lib/firmware`.

--- a/pru_firmware/src/AM335x_PRU.cmd
+++ b/pru_firmware/src/AM335x_PRU.cmd
@@ -1,0 +1,86 @@
+/****************************************************************************/
+/*  AM335x_PRU.cmd                                                          */
+/*  Copyright (c) 2015  Texas Instruments Incorporated                      */
+/*                                                                          */
+/*    Description: This file is a linker command file that can be used for  */
+/*                 linking PRU programs built with the C compiler and       */
+/*                 the resulting .out file on an AM335x device.             */
+/****************************************************************************/
+
+-cr								/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	PRU_IMEM		: org = 0x00000000 len = 0x00002000  /* 8kB PRU0 Instruction RAM */
+
+      PAGE 1:
+
+	/* RAM */
+
+	PRU_DMEM_0_1	: org = 0x00000000 len = 0x00002000 CREGISTER=24 /* 8kB PRU Data RAM 0_1 */
+	PRU_DMEM_1_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25 /* 8kB PRU Data RAM 1_0 */
+
+	  PAGE 2:
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00003000 CREGISTER=28 /* 12kB Shared RAM */
+
+	DDR			    : org = 0x80000000 len = 0x00000100	CREGISTER=31
+	L3OCMC			: org = 0x40000000 len = 0x00010000	CREGISTER=30
+
+
+	/* Peripherals */
+
+	PRU_CFG			: org = 0x00026000 len = 0x00000044	CREGISTER=4
+	PRU_ECAP		: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_IEP			: org = 0x0002E000 len = 0x0000031C	CREGISTER=26
+	PRU_INTC		: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_UART		: org = 0x00028000 len = 0x00000038	CREGISTER=7
+
+	DCAN0			: org = 0x481CC000 len = 0x000001E8	CREGISTER=14
+	DCAN1			: org = 0x481D0000 len = 0x000001E8	CREGISTER=15
+	DMTIMER2		: org = 0x48040000 len = 0x0000005C	CREGISTER=1
+	PWMSS0			: org = 0x48300000 len = 0x000002C4	CREGISTER=18
+	PWMSS1			: org = 0x48302000 len = 0x000002C4	CREGISTER=19
+	PWMSS2			: org = 0x48304000 len = 0x000002C4	CREGISTER=20
+	GEMAC			: org = 0x4A100000 len = 0x0000128C	CREGISTER=9
+	I2C1			: org = 0x4802A000 len = 0x000000D8	CREGISTER=2
+	I2C2			: org = 0x4819C000 len = 0x000000D8	CREGISTER=17
+	MBX0			: org = 0x480C8000 len = 0x00000140	CREGISTER=22
+	MCASP0_DMA		: org = 0x46000000 len = 0x00000100	CREGISTER=8
+	MCSPI0			: org = 0x48030000 len = 0x000001A4	CREGISTER=6
+	MCSPI1			: org = 0x481A0000 len = 0x000001A4	CREGISTER=16
+	MMCHS0			: org = 0x48060000 len = 0x00000300	CREGISTER=5
+	SPINLOCK		: org = 0x480CA000 len = 0x00000880	CREGISTER=23
+	TPCC			: org = 0x49000000 len = 0x00001098	CREGISTER=29
+	UART1			: org = 0x48022000 len = 0x00000088	CREGISTER=11
+	UART2			: org = 0x48024000 len = 0x00000088	CREGISTER=12
+
+	RSVD10			: org = 0x48318000 len = 0x00000100	CREGISTER=10
+	RSVD13			: org = 0x48310000 len = 0x00000100	CREGISTER=13
+	RSVD21			: org = 0x00032400 len = 0x00000100	CREGISTER=21
+	RSVD27			: org = 0x00032000 len = 0x00000100	CREGISTER=27
+
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU_DMEM_0_1, PAGE 1
+	.bss		>  PRU_DMEM_0_1, PAGE 1
+	.cio		>  PRU_DMEM_0_1, PAGE 1
+	.data		>  PRU_DMEM_0_1, PAGE 1
+	.switch		>  PRU_DMEM_0_1, PAGE 1
+	.sysmem		>  PRU_DMEM_0_1, PAGE 1
+	.cinit		>  PRU_DMEM_0_1, PAGE 1
+	.rodata		>  PRU_DMEM_0_1, PAGE 1
+	.rofardata	>  PRU_DMEM_0_1, PAGE 1
+	.farbss		>  PRU_DMEM_0_1, PAGE 1
+	.fardata	>  PRU_DMEM_0_1, PAGE 1
+
+	.resource_table > PRU_DMEM_0_1, PAGE 1
+}

--- a/pru_firmware/src/cm_wkup.h
+++ b/pru_firmware/src/cm_wkup.h
@@ -1,0 +1,29 @@
+#ifndef _CM_WKUP_H_
+#define _CM_WKUP_H_
+
+typedef struct {  // TODO find a proper header...
+  union {
+    volatile uint32_t CLKSTCTRL;
+
+    volatile struct {
+      unsigned CLKTRCTRL  : 2;    //1:0
+      unsigned undef2  : 13;  //14:2  - we don't use these
+      unsigned rsvd15  : 17;    //31:15
+    } CLKSTCTRL_bit;
+  };
+
+  uint8_t unimple4[0xbc-0x4];  // padding to align addresses
+
+  union {
+    volatile uint32_t ADC_TSC_CLKCTR;
+
+    volatile struct {
+      unsigned MODULEMODE  : 2;    //1:0
+      unsigned undef2  : 30;  //31:2  - we don't use these
+    } ADC_TSC_CLKCTR_bit;
+  };
+} cmWkup_reg_t;
+
+#define CM_WKUP (*((volatile cmWkup_reg_t*)0x44E00400))
+
+#endif

--- a/pru_firmware/src/gpio.h
+++ b/pru_firmware/src/gpio.h
@@ -1,0 +1,36 @@
+#ifndef _GPIO_H_
+#define _GPIO_H_
+
+typedef struct {  // TODO find a proper header...
+  union {
+    volatile uint32_t REVISION;
+
+    volatile struct {
+      unsigned MINOR  : 6;    //5:0
+      unsigned CUSTOM   : 2;    //7:6
+      unsigned MAJOR  : 3;    //10:8
+      unsigned RTL    : 5;    //15:11
+      unsigned FUNC   : 12;   //27:16
+      unsigned rsvd28   : 2;    //29:28
+      unsigned SCHEME   : 2;    //31:30
+    } REVISION_bit;
+  };
+
+  uint8_t unimpl4[0x134-0x4];  // padding to align addresses
+
+  volatile uint32_t OE;
+  volatile uint32_t DATAIN;
+  volatile uint32_t DATAOUT;
+
+  uint8_t unimpl140[0x190-0x13C-0x4];  // padding to align addresses
+
+  volatile uint32_t CLEARDATAOUT;
+  volatile uint32_t SETDATAOUT;
+} gpio_reg_t;
+
+#define GPIO0 (*((volatile gpio_reg_t*)0x44E07000))
+#define GPIO1 (*((volatile gpio_reg_t*)0x4804C000))
+#define GPIO2 (*((volatile gpio_reg_t*)0x481AC000))
+#define GPIO3 (*((volatile gpio_reg_t*)0x481AE000))
+
+#endif

--- a/pru_firmware/src/main_pru0.c
+++ b/pru_firmware/src/main_pru0.c
@@ -1,0 +1,162 @@
+#include <stdint.h>
+#include <pru_cfg.h>
+#include <pru_ctrl.h>
+#include "resource_table_pru1.h"
+
+
+// Register map headers
+#include <sys_tscAdcSs.h>  // ADC - in /usr/lib/ti/pru-software-support-package/include/am335x/sys_tscAdcSs.h
+#include "cm_wkup.h"
+#include "gpio.h"
+
+
+// Shared memory definitions
+#define ENCODER_MEM_OFFSET  16
+#define CAM_MEM_OFFSET  (ENCODER_MEM_OFFSET + 1)
+#define PRU_SHAREDMEM ((volatile unsigned int *)(0x10000)) // shared memory with Cortex A8 (Linux)
+
+
+// IO definitions
+#define LED_BATT1 (1<<27)  // (red) on GPIO0 - not recommended since Linux overwrites this regularly
+#define LED_BATT2 (1<<11)  // (green) on GPIO0 - not recommended since Linux overwrites this regularly
+#define LED_BATT3 (1<<29)  // (green) on GPIO1 - not recommended since Linux overwrites this regularly
+#define LED_BATT4 (1<<26)  // (green) on GPIO0 - not recommended since Linux overwrites this regularly
+
+#define LED_RED (1<<2)  // on GPIO2
+#define LED_GRN (1<<3)  // on GPIO3
+
+#define LED_USR0 (1<<21)  // (blue) on GPIO1
+#define LED_USR1 (1<<22)  // (blue) on GPIO1
+#define LED_USR3 (1<<24)  // (blue) on GPIO1
+
+#define LED_BUSY_GPIO GPIO2
+#define LED_BUSY_IO LED_RED
+
+#define CAM_SI_GPIO GPIO3
+#define CAM_SI_IO (1 << 17)
+#define CAM_CLK_GPIO GPIO3
+#define CAM_CLK_IO (1 << 20)
+#define CAM_AO_INP = 0  // ADC INP (positive in) channel for camera in
+
+
+// ADC helper prototypes
+void adc_init();
+uint16_t adc_read();
+
+
+// The main (top-level) PRU code
+int main() {
+  // Pulse the LED on quickly to indicate startup.
+  // You may want to remove this code so the main camera read code start immediately.
+  LED_BUSY_GPIO.SETDATAOUT = LED_BUSY_IO;
+  adc_init();
+  CAM_SI_GPIO.OE &= (~CAM_SI_IO) & (~CAM_CLK_IO);  // set the SI and CLK pins as output (we assume LED directions set by Linux)
+  CAM_SI_GPIO.CLEARDATAOUT = CAM_SI_IO;  // "initialize" SI low
+  CAM_CLK_GPIO.CLEARDATAOUT = CAM_CLK_IO;  // "initialize" CLK low
+  PRU_SHAREDMEM[CAM_MEM_OFFSET] = 0;
+  __delay_cycles(100*1000*200);
+  LED_BUSY_GPIO.CLEARDATAOUT = LED_BUSY_IO;
+  
+  while (1) {
+    while (PRU_SHAREDMEM[CAM_MEM_OFFSET] == 0);  // loop until read command from host
+    LED_BUSY_GPIO.SETDATAOUT = LED_BUSY_IO;
+    
+    CAM_SI_GPIO.SETDATAOUT = CAM_SI_IO;  // set SI high
+    __delay_cycles(200);  // you definitely have margin to play with here, and for the other __delay_cycles
+    CAM_CLK_GPIO.SETDATAOUT = CAM_CLK_IO;  // rising edge of CLK with SI asserted
+    __delay_cycles(200);
+    CAM_SI_GPIO.CLEARDATAOUT = CAM_SI_IO;
+    __delay_cycles(200);
+    
+    uint8_t i;
+    for (i=0; i<128; i++) {
+      CAM_CLK_GPIO.CLEARDATAOUT = CAM_CLK_IO;
+      PRU_SHAREDMEM[CAM_MEM_OFFSET + 1 + i] = adc_read();  // read on the falling CLK edge
+      // no need for a __delay_cycles here, since adc_read() takes 7.2us
+      CAM_CLK_GPIO.SETDATAOUT = CAM_CLK_IO;
+      __delay_cycles(200);
+    }
+    CAM_CLK_GPIO.CLEARDATAOUT = CAM_CLK_IO;
+    
+    PRU_SHAREDMEM[CAM_MEM_OFFSET] = 0;  // reset to zero to indicate done
+    LED_BUSY_GPIO.CLEARDATAOUT = LED_BUSY_IO;
+  }
+}
+
+
+// Initializes the ADC in "fast" mode
+// Based on the old PRU code at https://github.com/ucb-ee192/SkeletonBeagle/blob/master/pru_firmware/src/main_pru0.c
+void adc_init() {
+  while (CM_WKUP.ADC_TSC_CLKCTR_bit.MODULEMODE != 0x02) {
+    CM_WKUP.CLKSTCTRL_bit.CLKTRCTRL = 0;
+    CM_WKUP.ADC_TSC_CLKCTR_bit.MODULEMODE = 0x02;
+    /* Optional: implement timeout logic. */
+  }
+
+  /* 
+   * Set the ADC_TSC CTRL register. 
+   * Disable TSC_ADC_SS module so we can program it.
+   * Set step configuration registers to writable.
+   */
+  ADC_TSC.CTRL_bit.ENABLE = 0;
+  ADC_TSC.CTRL_bit.STEPCONFIG_WRITEPROTECT_N_ACTIVE_LOW = 1;
+
+  /* 
+   * make sure no step is enabled, until channel is read with read_adc(chan)  
+   * disable TS_CHARGE and Steps 1-16
+   */
+  ADC_TSC.STEPENABLE = ADC_TSC.STEPENABLE & 0xfffe0000;
+  
+  /* 
+   * set the ADC_TSC STEPCONFIG1 register for channel 0  
+   * Mode = 0; SW enabled, one-shot
+   * Averaging = 0; 1 sample "average"
+   * SEL_INP_SWC_3_0 = 0x0 = Channel 0
+   * use FIFO0
+   */
+  ADC_TSC.STEPCONFIG1_bit.MODE = 0;
+  ADC_TSC.STEPCONFIG1_bit.AVERAGING = 0;
+  ADC_TSC.STEPCONFIG1_bit.SEL_INP_SWC_3_0 = 0;
+  ADC_TSC.STEPCONFIG1_bit.FIFO_SELECT = 0;
+
+  /* make sure delay is also minimum. This is set to zero at reset, but just in case see if it makes any difference. */
+  /* sped up by factor of 6 by setting to zero. Perhaps it was set by other rc library code being run. 
+   * This gives 7.9 us per conversion
+   */
+  ADC_TSC.STEPDELAY1_bit.OPENDELAY = 0x0;
+  ADC_TSC.STEPDELAY1_bit.SAMPLEDELAY = 0x0;
+
+  /* 
+   * set the ADC_TSC CTRL register
+   * set step configuration registers to protected
+   * store channel ID tag if needed for debug
+   * Enable TSC_ADC_SS module
+   */
+  ADC_TSC.CTRL_bit.STEPCONFIG_WRITEPROTECT_N_ACTIVE_LOW = 0;
+  ADC_TSC.CTRL_bit.STEP_ID_TAG = 1;
+  ADC_TSC.CTRL_bit.ENABLE = 1;
+}
+
+// Reads the ADC, returning the raw 12b value
+uint16_t adc_read() {
+  while (ADC_TSC.FIFO0COUNT) {
+    (void)ADC_TSC.FIFO0DATA;  // perform a dummy read
+  }
+  
+  ADC_TSC.STEPENABLE_bit.STEP1 = 1;  // start the conversion
+  
+  while (ADC_TSC.FIFO0COUNT == 0) {
+    /*
+     * loop until value placed in fifo.
+     * Optional: implement timeout logic.
+     *
+     * Other potential options include: 
+     *   - configure PRU to receive an ADC interrupt. Note that 
+     *     END_OF_SEQUENCE does not mean that the value has been
+     *     loaded into the FIFO yet
+     *   - perform other actions, and periodically poll for 
+     *     FIFO0COUNT > 0
+     */
+  }
+  return ADC_TSC.FIFO0DATA_bit.ADCDATA;
+}

--- a/pru_firmware/src/main_pru0.c
+++ b/pru_firmware/src/main_pru0.c
@@ -11,8 +11,8 @@
 
 
 // Shared memory definitions
-#define ENCODER_MEM_OFFSET  16
-#define CAM_MEM_OFFSET  (ENCODER_MEM_OFFSET + 1)
+#define ENCODER_MEM_OFFSET  16  // shared memory offset originally used by tne encoder - which this code replaces
+#define CAM_MEM_OFFSET  (ENCODER_MEM_OFFSET + 1)  // don't use the memory location used by the encoder
 #define PRU_SHAREDMEM ((volatile unsigned int *)(0x10000)) // shared memory with Cortex A8 (Linux)
 
 
@@ -87,6 +87,7 @@ int main() {
 // Initializes the ADC in "fast" mode
 // Based on the old PRU code at https://github.com/ucb-ee192/SkeletonBeagle/blob/master/pru_firmware/src/main_pru0.c
 void adc_init() {
+  // Make sure the ADC's (and its clocks) are enabled.
   while (CM_WKUP.ADC_TSC_CLKCTR_bit.MODULEMODE != 0x02) {
     CM_WKUP.CLKSTCTRL_bit.CLKTRCTRL = 0;
     CM_WKUP.ADC_TSC_CLKCTR_bit.MODULEMODE = 0x02;
@@ -139,7 +140,7 @@ void adc_init() {
 
 // Reads the ADC, returning the raw 12b value
 uint16_t adc_read() {
-  while (ADC_TSC.FIFO0COUNT) {
+  while (ADC_TSC.FIFO0COUNT) {  // if there's any pending data in the queue, discard it
     (void)ADC_TSC.FIFO0DATA;  // perform a dummy read
   }
   

--- a/pru_firmware/src/main_pru1.c
+++ b/pru_firmware/src/main_pru1.c
@@ -1,0 +1,53 @@
+/*
+ * Source Modified by Zubeen Tolani < ZeekHuge - zeekhuge@gmail.com >
+ * Based on the examples distributed by TI
+ *
+ * Copyright (C) 2015 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	* Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	* Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the
+ *	  distribution.
+ *
+ *	* Neither the name of Texas Instruments Incorporated nor the names of
+ *	  its contributors may be used to endorse or promote products derived
+ *	  from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <pru_cfg.h>
+#include "resource_table_pru1.h"
+
+// The function is defined in pru1_asm_blinky.asm in same dir
+// We just need to add a declaration here, the defination can be
+// seperately linked
+extern void start(void);
+
+void main(void)
+{
+    /* Clear SYSCFG[STANDBY_INIT] to enable OCP master port */
+	CT_CFG.SYSCFG_bit.STANDBY_INIT = 0;
+
+	start();
+}
+

--- a/pru_firmware/src/pru1-servo.asm
+++ b/pru_firmware/src/pru1-servo.asm
@@ -1,0 +1,162 @@
+;*
+;* Copyright (C) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+;*
+;* This file is as an example to show how to develope
+;* and compile inline assembly code for PRUs
+;*
+;* This program is free software; you can redistribute it and/or modify
+;* it under the terms of the GNU General Public License version 2 as
+;* published by the Free Software Foundation.
+
+
+	.cdecls "main_pru1.c"
+
+DELAY	.macro time, reg
+	LDI32	reg, time
+	QBEQ	$E?, reg, 0
+$M?:	SUB	reg, reg, 1
+	QBNE	$M?, reg, 0
+$E?:
+	.endm
+
+
+	.clink
+	.global start
+start:
+	LDI 	R30, 0xFFFF
+	DELAY 	10000000, r11
+	LDI		R30, 0x0000
+	DELAY 	10000000, r11
+; 	JMP	start
+
+; 	HALT
+
+
+; these pin definitions are specific to SD-101C Robotics Cape
+    .asg    r30.t8,     CH1BIT  ; P8_27
+	.asg    r30.t10,    CH2BIT	; P8_28
+	.asg    r30.t9,     CH3BIT	; P8_29
+	.asg	r30.t11,	CH4BIT	; P8_30
+	.asg	r30.t6,		CH5BIT	; P8_39
+	.asg	r30.t7,		CH6BIT	; P8_40
+	.asg	r30.t4,		CH7BIT	; P8_41
+	.asg	r30.t5,		CH8BIT	; P8_42
+
+	.asg    C4,     CONST_SYSCFG
+	.asg    C28,    CONST_PRUSHAREDRAM
+
+	.asg	0x22000,	PRU0_CTRL
+	.asg    0x24000,    PRU1_CTRL       ; page 19
+	.asg    0x28,       CTPPR0          ; page 75
+
+	.asg	0x000,	OWN_RAM
+	.asg	0x020,	OTHER_RAM
+	.asg    0x100,	SHARED_RAM       ; This is so prudebug can find it.
+
+	LBCO	&r0, CONST_SYSCFG, 4, 4		; Enable OCP master port
+	CLR 	r0, r0, 4					; Clear SYSCFG[STANDBY_INIT] to enable OCP master port
+	SBCO	&r0, CONST_SYSCFG, 4, 4
+
+; Configure the programmable pointer register for PRU0 by setting c28_pointer[15:0]
+	LDI     r0, SHARED_RAM              ; Set C28 to point to shared RAM
+	LDI32   r1, PRU1_CTRL + CTPPR0		; Note we use beginning of shared ram unlike example which
+	SBBO    &r0, r1, 0, 4				;  page 25
+
+	LDI		r9, 0x0				; erase r9 to use to use later
+
+	LDI 	r0, 0x0				; clear internal counters
+	LDI 	r1, 0x0
+	LDI 	r2, 0x0
+	LDI 	r3, 0x0
+	LDI 	r4, 0x0
+	LDI 	r5, 0x0
+	LDI 	r6, 0x0
+	LDI32 	r7, 0x0
+	LDI 	r30, 0x0				; turn off GPIO outputs
+
+
+; Beginning of loop, should always take 48 instructions to complete
+CH1:
+	QBEQ	CLR1, r0, 0			; If timer is 0, jump to clear channel
+	SET	r30, CH1BIT			; If non-zero turn on the corresponding channel
+	SUB	r0, r0, 1			; Subtract one from timer
+	CLR	r9, r9.t1			; waste a cycle for timing
+	SBCO	&r9, CONST_PRUSHAREDRAM, 0, 4	; write 0 to shared memory
+CH2:
+	QBEQ	CLR2, r1, 0
+	SET	r30, CH2BIT
+	SUB	r1, r1, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 4, 4
+CH3:
+	QBEQ	CLR3, r2, 0
+	SET	r30, CH3BIT
+	SUB	r2, r2, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 8, 4
+CH4:
+	QBEQ	CLR4, r3, 0
+	SET	r30, CH4BIT
+	SUB	r3, r3, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 12, 4
+CH5:
+	QBEQ	CLR5, r4, 0
+	SET	r30, CH5BIT
+	SUB	r4, r4, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 16, 4
+CH6:
+	QBEQ	CLR6, r5, 0
+	SET	r30, CH6BIT
+	SUB	r5, r5, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 20, 4
+CH7:
+	QBEQ	CLR7, r6, 0
+	SET	r30, CH7BIT
+	SUB	r6, r6, 1
+	CLR	r9, r9.t1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 24, 4
+CH8:
+	QBEQ	CLR8, r7, 0
+	SET	r30, CH8BIT
+	SUB	r7, r7, 1
+	SBCO	&r9, CONST_PRUSHAREDRAM, 28, 4
+
+	QBA	CH1	; return to beginning of loop
+	; no need to waste a cycle for timing here because of the QBA above
+
+
+CLR1:
+	CLR	r30, CH1BIT			; turn off the corresponding channel
+	LBCO	&r0, CONST_PRUSHAREDRAM, 0, 4	; Load new timer register
+	QBA	CH2
+CLR2:
+	CLR	r30, CH2BIT
+	LBCO	&r1, CONST_PRUSHAREDRAM, 4, 4
+	QBA	CH3
+CLR3:
+	CLR	r30, CH3BIT
+	LBCO	&r2, CONST_PRUSHAREDRAM, 8, 4
+	QBA	CH4
+CLR4:
+	CLR	r30, CH4BIT
+	LBCO	&r3, CONST_PRUSHAREDRAM, 12, 4
+	QBA	CH5
+CLR5:
+	CLR	r30, CH5BIT
+	LBCO	&r4, CONST_PRUSHAREDRAM, 16, 4
+	QBA	CH6
+CLR6:
+	CLR	r30, CH6BIT
+	LBCO	&r5, CONST_PRUSHAREDRAM, 20, 4
+	QBA	CH7
+CLR7:
+	CLR	r30, CH7BIT
+	LBCO	&r6, CONST_PRUSHAREDRAM, 24, 4
+	QBA	CH8
+CLR8:
+	CLR	r30, CH8BIT
+	LBCO	&r7, CONST_PRUSHAREDRAM, 28, 4
+	QBA	CH1	; return to beginning of loop

--- a/pru_firmware/src/resource_table_pru1.h
+++ b/pru_firmware/src/resource_table_pru1.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	* Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	* Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the
+ *	  distribution.
+ *
+ *	* Neither the name of Texas Instruments Incorporated nor the names of
+ *	  its contributors may be used to endorse or promote products derived
+ *	  from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ *  ======== resource_table_empty.h ========
+ *
+ *  Define the resource table entries for all PRU cores. This will be
+ *  incorporated into corresponding base images, and used by the remoteproc
+ *  on the host-side to allocated/reserve resources.  Note the remoteproc
+ *  driver requires that all PRU firmware be built with a resource table.
+ *
+ *  This file contains an empty resource table.  It can be used either as:
+ *
+ *        1) A template, or
+ *        2) As-is if a PRU application does not need to configure PRU_INTC
+ *                  or interact with the rpmsg driver
+ *
+ */
+
+#ifndef _RSC_TABLE_PRU_H_
+#define _RSC_TABLE_PRU_H_
+
+#include <stddef.h>
+#include <rsc_types.h>
+
+struct my_resource_table {
+	struct resource_table base;
+
+	uint32_t offset[1]; /* Should match 'num' in actual definition */
+};
+
+#pragma DATA_SECTION(pru_remoteproc_ResourceTable, ".resource_table")
+#pragma RETAIN(pru_remoteproc_ResourceTable)
+struct my_resource_table pru_remoteproc_ResourceTable = {
+	1,	/* we're the first version that implements this */
+	0,	/* number of entries in the table */
+	0, 0,	/* reserved, must be zero */
+	0,	/* offset[0] */
+};
+
+#endif /* _RSC_TABLE_PRU_H_ */
+

--- a/src/LineLogger.h
+++ b/src/LineLogger.h
@@ -1,0 +1,60 @@
+#ifndef _LINE_LOGGER_H_
+#define _LINE_LOGGER_H_
+
+#include <cstdint>
+#include <ctime>
+#include <cstdio>
+#include <stdexcept>
+
+class LineLogger {
+public:
+  LineLogger() {
+    fp_ = NULL;
+
+    time_t t = time(NULL);
+    struct tm tm_struct = *localtime(&t);
+
+    snprintf(filename_, sizeof(filename_), "linescans.%d%02d%02d-%02d%02d%02d.csv",
+        tm_struct.tm_year + 1900, tm_struct.tm_mon + 1, tm_struct.tm_mday, tm_struct.tm_hour, tm_struct.tm_min, tm_struct.tm_sec);
+
+    fp_ = fopen(filename_, "w");
+    if (fp_ == NULL) {
+      throw std::runtime_error("LineLogger file open failed");
+    }
+    fprintf(fp_, "time (us), linescan, velocity\n");  // write header
+  }
+
+  void write_row(uint64_t time_us, uint16_t line[], float velocity) {
+    if (fp_ == NULL) {
+      throw std::runtime_error("LineLogger file not open");
+    }
+
+    fprintf(fp_, "%lld, ", time_us);
+    fprintf(fp_, "\"[");
+    for (size_t i=0; i<127; i++) {  // only read 127 because the last element doesn't need the trailing comma
+      fprintf(fp_, "%d, ", line[i]);
+    }
+    fprintf(fp_, "%d", line[127]);
+    fprintf(fp_, "]\", ");
+    fprintf(fp_, "%f", velocity);
+
+    fprintf(fp_, "\n");
+  }
+
+  void close() {
+    fclose(fp_);
+    fp_ = NULL;
+  }
+
+  const char* get_filename() {
+    return filename_;
+  }
+
+protected:
+  static constexpr size_t kFilenameLength = 128;
+
+  char filename_[kFilenameLength];
+  FILE* fp_;
+};
+
+#endif

--- a/src/PruCamera.h
+++ b/src/PruCamera.h
@@ -1,0 +1,46 @@
+#ifndef _PRU_CAMERA_H_
+#define _PRU_CAMERA_H_
+
+#include <stdexcept>
+#include <robotcontrol.h>
+#include <rc/pru.h>
+
+class PruCamera {
+public:
+  PruCamera() {
+  }
+
+  void init() {
+    if (rc_pru_start(0, "am335x-pru0-custom-fw")) {
+      throw std::runtime_error("PRU init failed");
+    }
+    pruSharedMem_ = rc_pru_shared_mem_ptr();
+  }
+
+  void stop() {
+    rc_pru_stop(0);
+    pruSharedMem_ = NULL;
+  }
+
+  void read(uint16_t* out) {
+    if (pruSharedMem_ == NULL) {
+      throw std::runtime_error("PRU not initialized, did you call PruCamera::init() ?");
+    }
+    while (pruSharedMem_[kPruMemOffset] != 0);  // wait for PRU to be ready; usually shouldn't happen
+
+    pruSharedMem_[kPruMemOffset] = 1;  // signal to start reading the camera
+
+    while (pruSharedMem_[kPruMemOffset] != 0);  // wait for PRU to finish; you might sleep the thread here
+
+    for (size_t i=0; i<128; i++) {
+      out[i] = pruSharedMem_[kPruMemOffset + 1 + i];
+    }
+  }
+
+protected:
+  volatile uint32_t* pruSharedMem_ = NULL;
+
+  static const size_t kPruMemOffset = (16 + 1);
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,8 @@ int main() {
 
   uint32_t i = 0;
   while (1) {
-    char buf[128];  // buffer to hold bytes read
+    // Process nonblocking console IO
+    char buf[128];  // buffer to hold bytes read from console
     int numRead = read(0, buf, 128);  // returns number of bytes read, up to 128
     while (numRead > 0 && (buf[numRead - 1] == '\n' || buf[numRead - 1] == '\r')) {
       numRead--;  // strip trailing newline characters
@@ -36,11 +37,14 @@ int main() {
       buf[numRead] = '\0';  // read() doesn't attach a null terminator, which makes strcmp and print happier
       if (strcmp(buf, "quit") == 0) {
         break;  // break out of the main loop, so the cleanup code can run
-      } else {
+      } else {  // you might add more commands here
         printf("unknown command '%s'\n", buf);
       }
     }
     
+    //
+    // YOUR MAIN LOOP CODE HERE
+    //
     
     // This simple code sets the LED equal to the state of the Pause (PAU) button.
     // Note that rc_button_get_state returns 1 when pressed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,17 @@
 #include <stdio.h>
 #include <robotcontrol.h>
 
+// Headers for nonblocking stdin + console
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+
 int main() {
+  fcntl(0, F_SETFL, fcntl(0, F_GETFL) | O_NONBLOCK);  // set stdin (file descriptor 0) to nonblocking mode
+
   // Initialize the Pause (PAU) button
   rc_button_init(RC_BTN_PIN_PAUSE, RC_BTN_POLARITY_NORM_HIGH,
       RC_BTN_DEBOUNCE_DEFAULT_US);
@@ -17,6 +27,21 @@ int main() {
 
   uint32_t i = 0;
   while (1) {
+    char buf[128];  // buffer to hold bytes read
+    int numRead = read(0, buf, 128);  // returns number of bytes read, up to 128
+    while (numRead > 0 && (buf[numRead - 1] == '\n' || buf[numRead - 1] == '\r')) {
+      numRead--;  // strip trailing newline characters
+    }
+    if (numRead > 0) {  // if read returned something that was "nonempty"
+      buf[numRead] = '\0';  // read() doesn't attach a null terminator, which makes strcmp and print happier
+      if (strcmp(buf, "quit") == 0) {
+        break;  // break out of the main loop, so the cleanup code can run
+      } else {
+        printf("unknown command '%s'\n", buf);
+      }
+    }
+    
+    
     // This simple code sets the LED equal to the state of the Pause (PAU) button.
     // Note that rc_button_get_state returns 1 when pressed.
     rc_led_set(RC_LED_RED, 1);


### PR DESCRIPTION
The logger largely is consistent with the format in the original [LineCamera.c](https://github.com/ucb-ee192/SkeletonBeagle/blob/master/LineCamera/LineCamera.c). Also adds non-blocking console in main, which is useful for cleaning up the PWM unit,

Update instructions, both drag'n'drop and git, will be posted separately.

Usage examples for Linux code:
## PruCamera
```c++
PruCamera camera;
camera.init();

// repeating in a loop, accounting for exposure time
uint16_t pixels[128];
camera.read(pixels);

// before program exit
camera.stop();
```

## LineLogger
```c++
LineLogger logger;
printf("Opened '%s'\n", logger.get_filename());

// repeating in a loop, every time the camera is read
uint16_t pixels[128];
// read into pixels array here
logger.write_row(rc_nanos_since_boot() / 1000, pixels, 0);

// before program exit
logger.close();
```
